### PR TITLE
Update Community Outreach section and normalize quotation marks

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,6 +157,9 @@
 					<a href="https://www.youtube.com/watch?v=RqvS1MhNu5I">"Cultivating awareness and understanding around Web Monetization"</a> — Elliot's talk on our efforts in the micropayments space.
 				</li>
 				<li>
+					<a href="https://community.webmonetization.org/akita">Web Monetization Forem</a> — Our grant reports and discussions with the Web Monetization Community.
+				</li>
+				<li>
 					<a href="https://twitter.com/esse_dev">Twitter</a> — We post updates here!
 				</li>
 				<li>

--- a/index.html
+++ b/index.html
@@ -148,6 +148,9 @@
 			</p>
 			<ul>
 				<li>
+					<a href="https://caseorganic.medium.com/grant-for-the-web-feedback-from-8-creators-1-year-in-676f9fb505cf">“Grant for the Web — Feedback from 8 Creators 1 Year In”</a>— <a href="https://twitter.com/caseorganic">Amber Case</a>'s collection of grantee interviews, reflections and takeaways — including some thoughts from us!
+				</li>
+				<li>
 					<a href="https://hackernoon.com/doing-my-bit-to-help-build-the-web-monetization-community-f5153wh6">“Doing My Bit To Help Build the Web Monetization Community”</a>— Blog post on Sharon's Web Monetization journey.
 				</li>
 				<li>

--- a/index.html
+++ b/index.html
@@ -111,9 +111,9 @@
 		<section>
 			<img
 				src="assets/banner2_a_web_monetization_story.svg"
-				alt="&#39;A Web Monetization Story&#39; Website Banner"
+				alt="'A Web Monetization Story' Website Banner"
 			/>
-			<h2 id="-a-web-monetization-story-website">&#39;A Web Monetization Story&#39; Website</h2>
+			<h2 id="-a-web-monetization-story-website">'A Web Monetization Story' Website</h2>
 			<p>
 				Check out our interactive Web Monetization tutorial for online creators.
 				We give you the basics of how to add Web Monetization to a site through
@@ -142,19 +142,19 @@
 			<img src="assets/banner3_outreach.svg" alt="Outreach Banner" />
 			<h2 id="community-outreach">Community Outreach</h2>
 			<p>
-				We&#39;ve spoken at two conferences; posted articles on DEV.to, Hackernoon and
+				We've spoken at two conferences; posted articles on DEV.to, Hackernoon and
 				the Web Monetization Forem; and engaged with the community on a bunch of platforms.
 				We hope to see you around the community!
 			</p>
 			<ul>
 				<li>
-					<a href="https://caseorganic.medium.com/grant-for-the-web-feedback-from-8-creators-1-year-in-676f9fb505cf">“Grant for the Web — Feedback from 8 Creators 1 Year In”</a>— <a href="https://twitter.com/caseorganic">Amber Case</a>'s collection of grantee interviews, reflections and takeaways — including some thoughts from us!
+					<a href="https://caseorganic.medium.com/grant-for-the-web-feedback-from-8-creators-1-year-in-676f9fb505cf">"Grant for the Web — Feedback from 8 Creators 1 Year In"</a>— <a href="https://twitter.com/caseorganic">Amber Case</a>'s collection of grantee interviews, reflections and takeaways — including some thoughts from us!
 				</li>
 				<li>
-					<a href="https://hackernoon.com/doing-my-bit-to-help-build-the-web-monetization-community-f5153wh6">“Doing My Bit To Help Build the Web Monetization Community”</a>— Blog post on Sharon's Web Monetization journey.
+					<a href="https://hackernoon.com/doing-my-bit-to-help-build-the-web-monetization-community-f5153wh6">"Doing My Bit To Help Build the Web Monetization Community"</a>— Blog post on Sharon's Web Monetization journey.
 				</li>
 				<li>
-					<a href="https://www.youtube.com/watch?v=RqvS1MhNu5I">&quot;Cultivating awareness and understanding around Web Monetization&quot;</a> — Elliot's talk on our efforts in the micropayments space.
+					<a href="https://www.youtube.com/watch?v=RqvS1MhNu5I">"Cultivating awareness and understanding around Web Monetization"</a> — Elliot's talk on our efforts in the micropayments space.
 				</li>
 				<li>
 					<a href="https://twitter.com/esse_dev">Twitter</a> — We post updates here!
@@ -174,9 +174,9 @@
 			<p>
 				Being a part of Web Monetization is awesome for a lot of reasons, but the
 				supportive and welcoming people are a big reason we love it. Check out
-				<a href="https://github.com/thomasbnt">Thomas</a>&#39;s
+				<a href="https://github.com/thomasbnt">Thomas</a>'s
 				<a href="https://github.com/thomasbnt/awesome-web-monetization">list of Web Monetization resources</a>
-				if you&#39;re interested in what the community is getting up to!
+				if you're interested in what the community is getting up to!
 			</p>
 			<p>
 				A big thanks to <a href="https://www.grantfortheweb.org/">Grant for the Web</a> for funding our project.

--- a/index.html
+++ b/index.html
@@ -41,13 +41,13 @@
 			<h1>The Akita Project</h1>
 			<p>
 				<a href="https://webmonetization.org/">Web Monetization</a> is an emerging idea
-				that’s paving the way for a more open, fair and inclusive web, to better support
+				that's paving the way for a more open, fair and inclusive web, to better support
 				both users and creators. Web Monetization provides a way for micropayments to be
 				streamed anonymously from users to websites.
 			</p>
 			<p>
 				In May 2020, we learned about Web Monetization. A few keywords stood out to us:
-				open, fair and inclusive. These words weren’t something we were used to seeing amongst
+				open, fair and inclusive. These words weren't something we were used to seeing amongst
 				monetization on the web, which generally involves targeted ads, paywalls and other
 				unfortunate things.
 			</p>
@@ -79,7 +79,7 @@
 			/>
 			<h2 id="akita-browser-extension">Akita Browser Extension</h2>
 			<p>
-				Whether or not you’re using a Web Monetization Provider such as Coil, you
+				Whether or not you're using a Web Monetization Provider such as Coil, you
 				can get started with Akita to find out how you engage with Web
 				Monetization on the internet.
 			</p>
@@ -148,10 +148,10 @@
 			</p>
 			<ul>
 				<li>
-					<a href="https://hackernoon.com/doing-my-bit-to-help-build-the-web-monetization-community-f5153wh6">“Doing My Bit To Help Build the Web Monetization Community”</a>— Blog post on Sharon’s Web Monetization journey.
+					<a href="https://hackernoon.com/doing-my-bit-to-help-build-the-web-monetization-community-f5153wh6">“Doing My Bit To Help Build the Web Monetization Community”</a>— Blog post on Sharon's Web Monetization journey.
 				</li>
 				<li>
-					<a href="https://www.youtube.com/watch?v=RqvS1MhNu5I">&quot;Cultivating awareness and understanding around Web Monetization&quot;</a> — Elliot’s talk on our efforts in the micropayments space.
+					<a href="https://www.youtube.com/watch?v=RqvS1MhNu5I">&quot;Cultivating awareness and understanding around Web Monetization&quot;</a> — Elliot's talk on our efforts in the micropayments space.
 				</li>
 				<li>
 					<a href="https://twitter.com/esse_dev">Twitter</a> — We post updates here!

--- a/index.html
+++ b/index.html
@@ -148,10 +148,10 @@
 			</p>
 			<ul>
 				<li>
-					<a href="https://caseorganic.medium.com/grant-for-the-web-feedback-from-8-creators-1-year-in-676f9fb505cf">"Grant for the Web — Feedback from 8 Creators 1 Year In"</a>— <a href="https://twitter.com/caseorganic">Amber Case</a>'s collection of grantee interviews, reflections and takeaways — including some thoughts from us!
+					<a href="https://caseorganic.medium.com/grant-for-the-web-feedback-from-8-creators-1-year-in-676f9fb505cf">"Grant for the Web — Feedback from 8 Creators 1 Year In"</a> — <a href="https://twitter.com/caseorganic">Amber Case</a>'s collection of grantee interviews, reflections and takeaways — including some thoughts from us!
 				</li>
 				<li>
-					<a href="https://hackernoon.com/doing-my-bit-to-help-build-the-web-monetization-community-f5153wh6">"Doing My Bit To Help Build the Web Monetization Community"</a>— Blog post on Sharon's Web Monetization journey.
+					<a href="https://hackernoon.com/doing-my-bit-to-help-build-the-web-monetization-community-f5153wh6">"Doing My Bit To Help Build the Web Monetization Community"</a> — Blog post on Sharon's Web Monetization journey.
 				</li>
 				<li>
 					<a href="https://www.youtube.com/watch?v=RqvS1MhNu5I">"Cultivating awareness and understanding around Web Monetization"</a> — Elliot's talk on our efforts in the micropayments space.

--- a/main.js
+++ b/main.js
@@ -1,1 +1,0 @@
-console.log('hello world');


### PR DESCRIPTION
### Changes
- normalize use of quotation marks to the standard quotation marks `'` and `"` 
- add article ["Grant for the Web — Feedback from 8 Creators 1 Year In"](https://caseorganic.medium.com/grant-for-the-web-feedback-from-8-creators-1-year-in-676f9fb505cf)— [Amber Case](https://twitter.com/caseorganic) to Community Outreach section
- add the Akita [Web Monetization Forem](https://community.webmonetization.org/akita) link to Community Outreach section

### Preview
<img src="https://user-images.githubusercontent.com/25834218/153537166-2561ad44-602b-4194-a9c9-5490bce0e9ce.png" width="500"/>
